### PR TITLE
[SPARK-53016][INFRA] Replace actions-rs/toolchain with dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,11 +40,10 @@ jobs:
           version: 23.x
 
       - name: Install minimal stable with clippy and rustfmt
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: default
           toolchain: stable
-          override: true
+          components: rustfmt
 
       - name: Format
         run: cargo fmt -- --check
@@ -63,11 +62,10 @@ jobs:
           version: 23.x
 
       - name: install minimal stable with clippy and rustfmt
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: default
           toolchain: stable
-          override: true
+          components: clippy
 
       - uses: Swatinem/rust-cache@v2
 
@@ -103,11 +101,9 @@ jobs:
           version: 23.x
 
       - name: install minimal stable with clippy and rustfmt
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: default
           toolchain: stable
-          override: true
 
       - uses: Swatinem/rust-cache@v2
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to replace `actions-rs/toolchain` with `dtolnay/rust-toolchain`.
Currently actions-rs doesn't work in spark-connect-rust repository.
https://github.com/apache/spark-connect-rust/actions/runs/16609256565
```
actions-rs/toolchain@v1 is not allowed to be used in apache/spark-connect-rust. Actions in this workflow must be: within a repository that belongs to your Enterprise account, created by GitHub, verified in the GitHub Marketplace, or matching the following: 1Password/load-secrets-action@581a835fb51b8e7ec56b71cf2ffddd7e68bb25e0, AdoptOpenJDK/install-jdk@*, BobAnkh/auto-generate-changelog@*, DavidAnson/markdownlint-cli2-action@992badcdf24e3b8eb7e87ff9287fe931bcb00c6e, DavidAnson/markdownlint-cli2-action@b4c9feab76d8025d1e83c653fa3990936df0e6c8, DavidAnson/markdownlint-cli2-action@v16, EnricoMi/publish-unit-test-result-action@*, JamesIves/github-pages-deploy-action@6c2d9db40f9296374acc17b90404b6e8864128c8, JamesIves/github-pages-deploy-action@881db5376404c5c8d621010bcbec0310b58d5e29, JamesIves/github-pages-deploy-action@v4.6.8, JustinBeckwith/linkinator-action@3d5ba091319fa7b0ac14703761eebb7d100e6f6d, JustinBeckwith/linkinator-action@v1.11.0, Kesin11/actions-timeline@427ee2cf860166e404d...
```

Also, actions-rs/toolchain is public archived.
https://github.com/actions-rs/toolchain

### Why are the changes needed?

Recovering CI on GA.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

I confirmed this change works on my repository.
https://github.com/sarutak/spark-connect-rust/actions/runs/16614429755

### Was this patch authored or co-authored using generative AI tooling?

No.
