### PR TITLE
[SPARK-53316] Add Byte literal type

### DIFF
--- a/crates/connect/src/expressions.rs
+++ b/crates/connect/src/expressions.rs
@@ -152,6 +152,14 @@ impl From<i16> for spark::expression::Literal {
     }
 }
 
+impl From<i8> for spark::expression::Literal {
+    fn from(value: i8) -> Self {
+        spark::expression::Literal {
+            literal_type: Some(spark::expression::literal::LiteralType::Byte(value as i32)),
+        }
+    }
+}
+
 impl<'a> From<&'a str> for spark::expression::Literal {
     fn from(value: &'a str) -> Self {
         spark::expression::Literal {
@@ -264,5 +272,30 @@ impl From<String> for spark::expression::cast::CastToType {
 impl From<DataType> for spark::expression::cast::CastToType {
     fn from(value: DataType) -> spark::expression::cast::CastToType {
         spark::expression::cast::CastToType::Type(value.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_i8_to_byte_literal() {
+        let val: i8 = 42;
+        let literal: spark::expression::Literal = val.into();
+        assert_eq!(
+            literal.literal_type,
+            Some(spark::expression::literal::LiteralType::Byte(42))
+        );
+    }
+
+    #[test]
+    fn test_i8_negative_to_byte_literal() {
+        let val: i8 = -128;
+        let literal: spark::expression::Literal = val.into();
+        assert_eq!(
+            literal.literal_type,
+            Some(spark::expression::literal::LiteralType::Byte(-128))
+        );
     }
 }

--- a/crates/connect/src/types.rs
+++ b/crates/connect/src/types.rs
@@ -584,6 +584,7 @@ impl_to_proto_type!(f32, Float);
 impl_to_proto_type!(f64, Double);
 impl_to_proto_type!(&str, String);
 impl_to_proto_type!(String, String);
+impl_to_proto_type!(i8, Byte);
 
 impl From<&[u8]> for spark::DataType {
     fn from(_value: &[u8]) -> spark::DataType {


### PR DESCRIPTION
## Summary
- Add `From<i8>` impl for `spark::expression::Literal` mapping to `LiteralType::Byte`
- Add `impl_to_proto_type!(i8, Byte)` for `spark::DataType` conversion

## Test plan
- [x] Unit test for positive i8 value (42)
- [x] Unit test for negative i8 boundary value (-128)
- [x] `cargo build` passes
- [x] `cargo fmt -- --check` passes