### PR TITLE
[SPARK-53316] Add DayTimeInterval literal type

### DIFF
--- a/crates/connect/src/expressions.rs
+++ b/crates/connect/src/expressions.rs
@@ -249,6 +249,22 @@ where
     }
 }
 
+/// Represents a Spark DayTimeInterval literal value.
+///
+/// Stores the interval as a total number of microseconds.
+#[derive(Clone, Debug)]
+pub struct DayTimeIntervalLiteral(pub i64);
+
+impl From<DayTimeIntervalLiteral> for spark::expression::Literal {
+    fn from(value: DayTimeIntervalLiteral) -> Self {
+        spark::expression::Literal {
+            literal_type: Some(spark::expression::literal::LiteralType::DayTimeInterval(
+                value.0,
+            )),
+        }
+    }
+}
+
 impl From<&str> for spark::expression::cast::CastToType {
     fn from(value: &str) -> Self {
         spark::expression::cast::CastToType::TypeStr(value.to_string())
@@ -264,5 +280,23 @@ impl From<String> for spark::expression::cast::CastToType {
 impl From<DataType> for spark::expression::cast::CastToType {
     fn from(value: DataType) -> spark::expression::cast::CastToType {
         spark::expression::cast::CastToType::Type(value.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_day_time_interval_literal() {
+        // 1 day in microseconds
+        let interval = DayTimeIntervalLiteral(86_400_000_000);
+        let literal: spark::expression::Literal = interval.into();
+        assert_eq!(
+            literal.literal_type,
+            Some(spark::expression::literal::LiteralType::DayTimeInterval(
+                86_400_000_000
+            ))
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Add `DayTimeIntervalLiteral(i64)` newtype storing the interval as total microseconds
- Add `From<DayTimeIntervalLiteral>` impl for `spark::expression::Literal` mapping to `LiteralType::DayTimeInterval`

## Test plan
- [x] Unit test verifying value round-trips correctly (1 day = 86,400,000,000 microseconds)
- [x] `cargo build` passes
- [x] `cargo fmt -- --check` passes