### PR TITLE
[SPARK-52428] Add Column comparison methods (gt, lt, ge, le)

### DIFF
--- a/crates/connect/src/column.rs
+++ b/crates/connect/src/column.rs
@@ -325,6 +325,26 @@ impl Column {
         invoke_func("or", vec![self, other.into()])
     }
 
+    /// Returns a boolean column for `self > other`.
+    pub fn gt(self, other: impl Into<Column>) -> Column {
+        invoke_func(">", vec![self, other.into()])
+    }
+
+    /// Returns a boolean column for `self < other`.
+    pub fn lt(self, other: impl Into<Column>) -> Column {
+        invoke_func("<", vec![self, other.into()])
+    }
+
+    /// Returns a boolean column for `self >= other`.
+    pub fn ge(self, other: impl Into<Column>) -> Column {
+        invoke_func(">=", vec![self, other.into()])
+    }
+
+    /// Returns a boolean column for `self <= other`.
+    pub fn le(self, other: impl Into<Column>) -> Column {
+        invoke_func("<=", vec![self, other.into()])
+    }
+
     /// A filter expression that evaluates to true is the expression is null
     pub fn is_null(self) -> Column {
         invoke_func("isnull", vec![self])
@@ -509,5 +529,59 @@ impl Not for Column {
 
     fn not(self) -> Self::Output {
         invoke_func("not", vec![self])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::functions::{col, lit};
+    use crate::spark;
+
+    #[test]
+    fn test_column_gt() {
+        let col = col("age").gt(lit(27));
+        match col.expression.expr_type {
+            Some(spark::expression::ExprType::UnresolvedFunction(ref f)) => {
+                assert_eq!(f.function_name, ">");
+                assert_eq!(f.arguments.len(), 2);
+            }
+            _ => panic!("Expected UnresolvedFunction for gt"),
+        }
+    }
+
+    #[test]
+    fn test_column_lt() {
+        let col = col("age").lt(lit(27));
+        match col.expression.expr_type {
+            Some(spark::expression::ExprType::UnresolvedFunction(ref f)) => {
+                assert_eq!(f.function_name, "<");
+                assert_eq!(f.arguments.len(), 2);
+            }
+            _ => panic!("Expected UnresolvedFunction for lt"),
+        }
+    }
+
+    #[test]
+    fn test_column_ge() {
+        let col = col("age").ge(lit(27));
+        match col.expression.expr_type {
+            Some(spark::expression::ExprType::UnresolvedFunction(ref f)) => {
+                assert_eq!(f.function_name, ">=");
+                assert_eq!(f.arguments.len(), 2);
+            }
+            _ => panic!("Expected UnresolvedFunction for ge"),
+        }
+    }
+
+    #[test]
+    fn test_column_le() {
+        let col = col("age").le(lit(27));
+        match col.expression.expr_type {
+            Some(spark::expression::ExprType::UnresolvedFunction(ref f)) => {
+                assert_eq!(f.function_name, "<=");
+                assert_eq!(f.arguments.len(), 2);
+            }
+            _ => panic!("Expected UnresolvedFunction for le"),
+        }
     }
 }


### PR DESCRIPTION
Closes #42

## Summary
- Add `Column::gt(other)`, `lt(other)`, `ge(other)`, `le(other)` comparison methods
- Uses same `invoke_func` pattern as existing `eq`, `and`, `or`
- Enables method chaining: `col("age").gt(lit(27))`

## Test plan
- [x] `test_column_gt` — verifies `>` function expression
- [x] `test_column_lt` — verifies `<` function expression
- [x] `test_column_ge` — verifies `>=` function expression
- [x] `test_column_le` — verifies `<=` function expression
- [x] `cargo build` passes
- [x] `cargo fmt -- --check` passes