### PR TITLE
[SPARK-52428] Add ergonomic convenience methods for catalog and config APIs

### DIFF
--- a/crates/connect/src/catalog.rs
+++ b/crates/connect/src/catalog.rs
@@ -78,6 +78,13 @@ impl Catalog {
         self.spark_session.client().execute_command(plan).await
     }
 
+    /// Returns a list of all catalogs in this session.
+    ///
+    /// Convenience method equivalent to `list_catalogs(None)`.
+    pub async fn list_all_catalogs(self) -> Result<RecordBatch, SparkError> {
+        self.list_catalogs(None).await
+    }
+
     /// Returns a list of catalogs in this session
     pub async fn list_catalogs(self, pattern: Option<&str>) -> Result<RecordBatch, SparkError> {
         let pattern = pattern.map(|val| val.to_owned());
@@ -119,6 +126,13 @@ impl Catalog {
         let plan = LogicalPlanBuilder::from(rel_type).plan_root();
 
         self.spark_session.client().execute_command(plan).await
+    }
+
+    /// Returns a list of all databases in this session.
+    ///
+    /// Convenience method equivalent to `list_databases(None)`.
+    pub async fn list_all_databases(self) -> Result<RecordBatch, SparkError> {
+        self.list_databases(None).await
     }
 
     /// Returns a list of databases in this session
@@ -166,6 +180,13 @@ impl Catalog {
         Catalog::arrow_to_bool(record)
     }
 
+    /// Returns a list of all tables/views in the current database.
+    ///
+    /// Convenience method equivalent to `list_tables(None, None)`.
+    pub async fn list_all_tables(self) -> Result<RecordBatch, SparkError> {
+        self.list_tables(None, None).await
+    }
+
     /// Returns a list of tables/views in the specific database
     pub async fn list_tables(
         self,
@@ -196,6 +217,13 @@ impl Catalog {
         let plan = LogicalPlanBuilder::from(rel_type).plan_root();
 
         self.spark_session.client().to_arrow(plan).await
+    }
+
+    /// Returns a list of all functions registered in the current database.
+    ///
+    /// Convenience method equivalent to `list_functions(None, None)`.
+    pub async fn list_all_functions(self) -> Result<RecordBatch, SparkError> {
+        self.list_functions(None, None).await
     }
 
     /// Returns a list of functions registered in the specified database.

--- a/crates/connect/src/conf.rs
+++ b/crates/connect/src/conf.rs
@@ -123,6 +123,13 @@ impl RunTimeConfig {
         Ok(val)
     }
 
+    /// Get a configuration value by key, returning an error if not set.
+    ///
+    /// This is a convenience method equivalent to `get(key, None)`.
+    pub async fn get_value(&mut self, key: &str) -> Result<String, SparkError> {
+        self.get(key, None).await
+    }
+
     /// Indicates whether the configuration property with the given key is modifiable in the current session.
     pub async fn is_modifable(&mut self, key: &str) -> Result<bool, SparkError> {
         let op_type = spark::config_request::operation::OpType::IsModifiable(


### PR DESCRIPTION
## Summary
Reduce boilerplate for common API calls that almost always use `None` defaults:

- `catalog.list_all_tables()` — convenience for `list_tables(None, None)`
- `catalog.list_all_databases()` — convenience for `list_databases(None)`
- `catalog.list_all_catalogs()` — convenience for `list_catalogs(None)`
- `catalog.list_all_functions()` — convenience for `list_functions(None, None)`
- `conf.get_value(key)` — convenience for `get(key, None)`

## Test plan
- [x] `cargo build` passes
- [x] `cargo fmt -- --check` passes